### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.8.5-alpine as builder
+ARG GOPROXY_VERSION=master
+RUN apk update && apk upgrade && \
+    apk add --no-cache git && cd /go/src/ && git clone https://github.com/snail007/goproxy && \
+	cd goproxy && git checkout ${GOPROXY_VERSION} && \
+    go get && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o proxy
+FROM alpine:3.7
+COPY --from=builder /go/src/goproxy/proxy /
+CMD /proxy ${OPTS}


### PR DESCRIPTION
Fixes #50 
Note: change branch to dev

This pull request adds a Dockerfile to root of project. Dockerfile uses multistage build and alpine project to comply with best practices. Uses golang 1.8.5 for building as noted in the project README.md and will be pretty small image. total extracted size will be 17.3MB for goproxy version 4.7.

The default build process builds the master branch (latest commits/ cutting edge), and it can be configured to build specific version, just edit Dockerfile before build, following builds release version 4.7:
```
ARG GOPROXY_VERSION=v4.7
```

To Run:
1. Clone the repository and cd into it.
```
sudo docker build .
```
2. Tag the image:
```
sudo docker tag <id from previous step>  goproxy/goproxy:latest
```
3. Run! 
Just put your arguments to proxy binary in the OPTS environmental variable (this is just a sample http proxy):
```
sudo docker run -d --restart=always --name goproxy -e OPTS="http -p :33080" -p 33080:33080 goproxy/goproxy:latest
```
4. View logs:
```
sudo docker logs -f goproxy
```

You can even create a dockerhub account an push each release image to, so users can use docker pull to access the desired version immediately.
