### PR TITLE
HTTP Basic 认证失败返回的 WWW-Authenticate 更正为 Proxy-Authenticate

### DIFF
--- a/utils/structs.go
+++ b/utils/structs.go
@@ -427,7 +427,7 @@ func (req *HTTPRequest) GetAuthDataStr() (basicInfo string, err error) {
 
 	authorization = strings.Trim(authorization, " \r\n\t")
 	if authorization == "" {
-		fmt.Fprintf((*req.conn), "HTTP/1.1 %s Unauthorized\r\nWWW-Authenticate: Basic realm=\"\"\r\n\r\nUnauthorized", "407")
+		fmt.Fprintf((*req.conn), "HTTP/1.1 %s Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"\"\r\n\r\nProxy Authentication Required", "407")
 		CloseConn(req.conn)
 		err = errors.New("require auth header data")
 		return
@@ -463,7 +463,7 @@ func (req *HTTPRequest) BasicAuth() (err error) {
 	authOk := (*req.basicAuth).Check(string(user), addr[0], URL)
 	//log.Printf("auth %s,%v", string(user), authOk)
 	if !authOk {
-		fmt.Fprintf((*req.conn), "HTTP/1.1 %s Unauthorized\r\n\r\nUnauthorized", "407")
+		fmt.Fprintf((*req.conn), "HTTP/1.1 %s Proxy Authentication Required\r\n\r\nProxy Authentication Required", "407")
 		CloseConn(req.conn)
 		err = fmt.Errorf("basic auth fail")
 		return


### PR DESCRIPTION
使用其它 HTTP 代理服务器（如 squid）时，若开启 HTTP Basic 用户认证，则浏览器如 Chrome 在不指定用户名密码的情况下使用代理服务器访问网页时，会弹出一个认证窗口，要求用户输入。但是现在 goproxy 作为代理服务器时，则直接返回 Unauthorized。在配合一些可以自动输入代理用户名密码的浏览器插件（如 SwitchyOmega）时，这些插件无法正常工作。

在进行了一定的调查以后，发现 goproxy 在 HTTP Basic 认证失败后返回给客户端的是状态码 407 和 HTTP 头 WWW-Authenticate。在查看过 Mozilla 的 HTTP 头说明文档后可以发现，WWW-Authenticate 通常是和状态码 401 一起使用的，代表直接访问网页时要求认证。而在 HTTP 代理服务器中应该使用的是状态码 407 和 Proxy-Authenticate。

在将 WWW-Authenticate 更改为 Proxy-Authenticate 后，浏览器使用 goproxy 和其它代理服务器时的行为一致了，浏览器代理插件也正常工作了。

我顺便改了下返回给客户端的状态码描述信息，401 是 Unauthorized，而 407 是 Proxy Authentication Required。

我将这部分代码提交了，希望能合并到 goproxy 的主线上，谢谢！

以下是参考的 Mozilla 的文档：
[WWW-Authenticate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate)
[Proxy-Authenticate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authenticate)