### PR TITLE
services: simplify switch statements with case clause lists

### DIFF
--- a/install_auto.sh
+++ b/install_auto.sh
@@ -5,7 +5,7 @@ if [ -e /tmp/proxy ]; then
 fi
 mkdir /tmp/proxy
 cd /tmp/proxy
-wget https://github.com/snail007/goproxy/releases/download/v6.1/proxy-linux-amd64.tar.gz
+wget https://github.com/snail007/goproxy/releases/download/v6.0/proxy-linux-amd64.tar.gz
 
 # #install proxy
 tar zxvf proxy-linux-amd64.tar.gz

--- a/install_auto.sh
+++ b/install_auto.sh
@@ -5,7 +5,7 @@ if [ -e /tmp/proxy ]; then
 fi
 mkdir /tmp/proxy
 cd /tmp/proxy
-wget https://github.com/snail007/goproxy/releases/download/v6.0/proxy-linux-amd64.tar.gz
+wget https://github.com/snail007/goproxy/releases/download/v6.1/proxy-linux-amd64.tar.gz
 
 # #install proxy
 tar zxvf proxy-linux-amd64.tar.gz

--- a/services/socks/socks.go
+++ b/services/socks/socks.go
@@ -462,11 +462,7 @@ func (s *Socks) proxyTCP(inConn *net.Conn, serverConn *socks.ServerConn) {
 }
 func (s *Socks) GetParentConn(parentAddress string, serverConn *socks.ServerConn) (outConn net.Conn, err interface{}) {
 	switch *s.cfg.ParentType {
-	case "kcp":
-		fallthrough
-	case "tls":
-		fallthrough
-	case "tcp":
+	case "kcp", "tls", "tcp":
 		if *s.cfg.ParentType == "tls" {
 			var _conn tls.Conn
 			_conn, err = utils.TlsConnectHost(parentAddress, *s.cfg.Timeout, s.cfg.CertBytes, s.cfg.KeyBytes, s.cfg.CaCertBytes)

--- a/services/sps/sps.go
+++ b/services/sps/sps.go
@@ -273,11 +273,7 @@ func (s *SPS) callback(inConn net.Conn) {
 	var err error
 	lbAddr := ""
 	switch *s.cfg.ParentType {
-	case "kcp":
-		fallthrough
-	case "tcp":
-		fallthrough
-	case "tls":
+	case "kcp", "tcp", "tls":
 		lbAddr, err = s.OutToTCP(&inConn)
 	default:
 		err = fmt.Errorf("unkown parent type %s", *s.cfg.ParentType)

--- a/services/tcp/tcp.go
+++ b/services/tcp/tcp.go
@@ -160,11 +160,7 @@ func (s *TCP) callback(inConn net.Conn) {
 	var err error
 	lbAddr := ""
 	switch *s.cfg.ParentType {
-	case "kcp":
-		fallthrough
-	case "tcp":
-		fallthrough
-	case "tls":
+	case "kcp", "tcp", "tls":
 		err = s.OutToTCP(&inConn)
 	case "udp":
 		s.OutToUDP(&inConn)

--- a/services/udp/udp.go
+++ b/services/udp/udp.go
@@ -141,9 +141,7 @@ func (s *UDP) callback(listener *net.UDPConn, packet []byte, localAddr, srcAddr 
 		}
 	}()
 	switch *s.cfg.ParentType {
-	case "tcp":
-		fallthrough
-	case "tls":
+	case "tcp", "tls":
 		s.OutToTCP(packet, localAddr, srcAddr)
 	case "udp":
 		s.OutToUDP(packet, localAddr, srcAddr)


### PR DESCRIPTION
Case clause lists are simpler and more compact than
multiple cases with fallthrough.

Found using https://go-critic.github.io/overview#emptyFallthrough-ref