### PR TITLE
remove some commented-out (dead) code

### DIFF
--- a/core/cs/server/server.go
+++ b/core/cs/server/server.go
@@ -230,7 +230,6 @@ func (s *ServerChannel) ListenKCP(config kcpcfg.KCPConfigArgs, fn func(conn net.
 				}
 			}()
 			for {
-				//var conn net.Conn
 				conn, err := lis.AcceptKCP()
 				if err == nil {
 					go func() {

--- a/services/mux/mux_bridge.go
+++ b/services/mux/mux_bridge.go
@@ -216,7 +216,6 @@ func (s *MuxBridge) handler(inConn net.Conn) {
 			v.(*smux.Session).Close()
 		}
 		group.Set(index, session)
-		// s.clientControlConns.Set(key, session)
 		go func() {
 			defer func() {
 				if e := recover(); e != nil {

--- a/services/sps/sps.go
+++ b/services/sps/sps.go
@@ -363,7 +363,6 @@ func (s *SPS) OutToTCP(inConn *net.Conn) (lbAddr string, err error) {
 			request.HTTPSReply()
 			//s.log.Printf("https reply: %s", request.Host)
 		} else {
-			//forwardBytes = bytes.TrimRight(request.HeadBuf,"\r\n")
 			forwardBytes = request.HeadBuf
 		}
 		address = request.Host
@@ -412,7 +411,6 @@ func (s *SPS) OutToTCP(inConn *net.Conn) (lbAddr string, err error) {
 		selectAddr = address
 	}
 	lbAddr = s.lb.Select(selectAddr, *s.cfg.LoadBalanceOnlyHA)
-	//lbAddr = s.lb.Select((*inConn).RemoteAddr().String())
 	outConn, err = s.GetParentConn(lbAddr)
 	if err != nil {
 		s.log.Printf("connect to %s , err:%s", lbAddr, err)


### PR DESCRIPTION
There are much more places, removed only few of them
to make review simpler (we can remove more later).

Found using https://go-critic.github.io/overview#commentedOutCode-ref