### PR TITLE
simplify (*x).f to x.f where it does not change the semantics

### DIFF
--- a/services/http/http.go
+++ b/services/http/http.go
@@ -172,7 +172,7 @@ func (s *HTTP) InitService() (err error) {
 		s.InitLB()
 	}
 	if *s.cfg.DNSAddress != "" {
-		(*s).domainResolver = dnsx.NewDomainResolver(*s.cfg.DNSAddress, *s.cfg.DNSTTL, s.log)
+		s.domainResolver = dnsx.NewDomainResolver(*s.cfg.DNSAddress, *s.cfg.DNSTTL, s.log)
 	}
 	if *s.cfg.ParentType == "ssh" {
 		err = s.ConnectSSH()

--- a/services/sps/sps.go
+++ b/services/sps/sps.go
@@ -145,7 +145,7 @@ func (s *SPS) CheckArgs() (err error) {
 func (s *SPS) InitService() (err error) {
 
 	if *s.cfg.DNSAddress != "" {
-		(*s).domainResolver = dnsx.NewDomainResolver(*s.cfg.DNSAddress, *s.cfg.DNSTTL, s.log)
+		s.domainResolver = dnsx.NewDomainResolver(*s.cfg.DNSAddress, *s.cfg.DNSTTL, s.log)
 	}
 
 	if len(*s.cfg.Parent) > 0 {

--- a/services/tcp/tcp.go
+++ b/services/tcp/tcp.go
@@ -208,8 +208,8 @@ func (s *TCP) OutToUDP(inConn *net.Conn) (err error) {
 	srcAddr := ""
 	defer func() {
 		if item != nil {
-			(*(*item).conn).Close()
-			(*item).udpConn.Close()
+			(*item.conn).Close()
+			item.udpConn.Close()
 			s.udpConns.Remove(srcAddr)
 			(*inConn).Close()
 		}
@@ -252,8 +252,8 @@ func (s *TCP) OutToUDP(inConn *net.Conn) (err error) {
 		} else {
 			item = v.(*UDPConnItem)
 		}
-		(*item).touchtime = time.Now().Unix()
-		go (*item).udpConn.Write(body)
+		item.touchtime = time.Now().Unix()
+		go item.udpConn.Write(body)
 	}
 }
 func (s *TCP) UDPRevecive(key string) {


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#underef-ref